### PR TITLE
Add missing dataclasses dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ name }}
@@ -27,8 +27,8 @@ outputs:
       run:
         - python >=3.6
         - appdirs
-        - attrs >=18.1.0
         - click >=7.1.2
+        - dataclasses >=0.6
         - mypy_extensions >=0.4.3
         - pathspec >=0.6,<1
         - regex

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,8 +36,11 @@ outputs:
         - typed-ast >=1.4.0
         - typing_extensions >=3.7.4
     test:
+      requires:
+        - pip
       commands:
         - black --help
+        - pip check
 
   - name: {{ name }}d
     build:


### PR DESCRIPTION
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

black 20.8 added a dependency on dataclasses instead of attrs in psf/black#1116. This isn't present on python 3.6 so black from conda-forge fails in the same manner as https://github.com/psf/black/issues/1645. 

```
$ conda create -p ENV python=3.6 black && \
  conda activate ENV/ && \
  black --version

Traceback (most recent call last):
...
packages/black/__init__.py", line 49, in <module>
    from dataclasses import dataclass, field, replace
ModuleNotFoundError: No module named 'dataclasses'
```

I've been advised that conda-forge's dataclasses is an empty package on python >3.6, so that it's not necessary to use a selector in `meta.yaml` to constrain the versions.