### PR TITLE
Don't require dataclasses for python 3.7+

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 7de4cfc7eb6b710de325712d40125689101d21d25283eed7e9998722cf10eb91
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ outputs:
         - python >=3.6
         - platformdirs >=2
         - click >=7.1.2
-        - dataclasses >=0.6
+        - dataclasses >=0.6 # [py<37]
         - mypy_extensions >=0.4.3
         - pathspec >=0.9,<1
         - regex >=2020.1.8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ outputs:
         - python >=3.6
         - platformdirs >=2
         - click >=7.1.2
-        - dataclasses >=0.6 # [py<37]
+        - dataclasses >=0.6  # [py<37]
         - mypy_extensions >=0.4.3
         - pathspec >=0.9,<1
         - regex >=2020.1.8


### PR DESCRIPTION
dataclasses is now in the standard library and shouldn't be installed

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
