### PR TITLE
Update dependency for typed-ast

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ name }}
@@ -32,7 +32,7 @@ outputs:
         - mypy_extensions >=0.4.3
         - pathspec >=0.9,<1
         - tomli >=1.1.0
-        - typed-ast >=1.4.2
+        - typed-ast >=1.5.0
         - typing_extensions >=3.10,!=3.10.0.1
     test:
       requires:


### PR DESCRIPTION
typed-ast has an [issue](https://github.com/python/typed_ast/issues/169#issuecomment-964360487) which will lead to error: undefined symbol _PyUnicode_DecodeUnicodeEscape

They fix this error in `1.5.0`, so here comes the update.
