### PR TITLE
move blackd entry point to avoid ClobberWarning

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 1c7b8d606e728a41ea1ccbd7264677e494e87cf630e399262ced92d4a8dac940
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ name }}
@@ -19,6 +19,7 @@ outputs:
       skip: true  # [py<36]
       entry_points:
         - black = black:patched_main
+        - blackd = blackd:patched_main
     requirements:
       build:
         - python                                 # [build_platform != target_platform]
@@ -51,8 +52,6 @@ outputs:
       noarch: python
       # Skip this package for cross-builds. We will only need a single upload anyways
       skip: true  # [not linux64]
-      entry_points:
-        - blackd = blackd:patched_main
     requirements:
       run:
         - {{ pin_subpackage('black', max_pin='x.x.x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,6 +46,7 @@ outputs:
       commands:
         - black --help
         - pip check
+        - which blackd || where blackd
 
   - name: {{ name }}d
     build:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

At present, `(bin|Scripts)/blackd(.exe)?` is packaged in `black` _no matter what_ by `setuptools`, even if it doesn't have the supporting dependency.

This leads to a `ClobberWarning` in e.g. `constructor` when installed with `blackd`: it _works_ (because `blackd` is installed last), but still probably not a great side-effect of multiple outputs in this case.

This PR moved the entry_point declaration to `black`.